### PR TITLE
Bug: Division by zero error on products #15

### DIFF
--- a/bangazonapi/admin.py
+++ b/bangazonapi/admin.py
@@ -1,3 +1,17 @@
 from django.contrib import admin
-
+# from bangazonapi.models.product import Product
+from bangazonapi.models import Product, Customer, Favorite, Order, OrderProduct, Payment, ProductCategory, ProductRating, Recommendation, Rating
+"""
+[summary]
+"""
 # Register your models here.
+admin.site.register(Customer)
+admin.site.register(Favorite)
+admin.site.register(Order)
+admin.site.register(OrderProduct)
+admin.site.register(Payment)
+admin.site.register(Product)
+admin.site.register(ProductCategory)
+admin.site.register(ProductRating)
+admin.site.register(Rating)
+admin.site.register(Recommendation)

--- a/bangazonapi/apps.py
+++ b/bangazonapi/apps.py
@@ -2,4 +2,8 @@ from django.apps import AppConfig
 
 
 class BangazonapiConfig(AppConfig):
+    """
+this is a doc string
+"""
+    default_auto_field = 'django.db.models.BigAutoField'
     name = 'bangazonapi'

--- a/bangazonapi/models/__init__.py
+++ b/bangazonapi/models/__init__.py
@@ -1,5 +1,5 @@
-from .customer import Customer
 from .order import Order
+from .customer import Customer
 from .orderproduct import OrderProduct
 from .payment import Payment
 from .product import Product
@@ -8,3 +8,5 @@ from .recommendation import Recommendation
 from .rating import Rating
 from .favorite import Favorite
 from .productrating import ProductRating
+"""[summary]
+"""

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,8 +62,12 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
-        return avg
+        try:
+            avg = total_rating / len(ratings)
+            return avg
+        except ZeroDivisionError:
+            return "no avarage rating"
+
 
     class Meta:
         verbose_name = ("product")

--- a/bangazonapi/models/recommendation.py
+++ b/bangazonapi/models/recommendation.py
@@ -4,7 +4,9 @@ from .product import Product
 
 
 class Recommendation(models.Model):
-
+    """
+    [summary]
+    """
     customer = models.ForeignKey(Customer, related_name='customer', on_delete=models.DO_NOTHING,)
     product = models.ForeignKey(Product, on_delete=models.DO_NOTHING,)
     recommender = models.ForeignKey(Customer, related_name='recommender', on_delete=models.DO_NOTHING,)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -7,20 +7,7 @@ from rest_framework import status
 from bangazonapi.models import Payment, Customer
 
 
-class PaymentSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for Payment
 
-    Arguments:
-        serializers
-    """
-    class Meta:
-        model = Payment
-        url = serializers.HyperlinkedIdentityField(
-            view_name='payment',
-            lookup_field='id'
-        )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
 
 
 class Payments(ViewSet):
@@ -89,3 +76,19 @@ class Payments(ViewSet):
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})
         return Response(serializer.data)
+
+
+class PaymentSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for Payment
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = Payment
+        url = serializers.HyperlinkedIdentityField(
+            view_name='payment',
+            lookup_field='id'
+        )
+        fields = ('id', 'url', 'merchant_name', 'account_number',
+                  'expiration_date', 'create_date')


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Item 1- added a Try
- Item 2 added an Except
- Item 3 added a Return "no avarage rating" if they do not have one. only product 50 seems to have an average rating.

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET for the Products.py to get all Products and changed their average rating to "no avarage_rating  instead of giving the ZeroDivisionError at /products.

try:
            avg = total_rating / len(ratings)
            return avg
        except ZeroDivisionError:
            return "no avarage rating"
