### PR TITLE
corrected profile returned Fixes #22

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,7 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            current_user = Customer.objects.get(user=4)
+            current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             serializer = ProfileSerializer(


### PR DESCRIPTION
Description of PR that completes issue here... 
the issue being that no matter who the user that was singed in, user id 4 was also showing when we attempted to get a users profile. we need to update it to get the current users profile.

## Changes

- Item 1 edited the TRY for Profile.py for the "list" function to get the current users profile. it was showing for ID 4 and changed it to request the current authorized user to return that users profile only. 

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET Profiles gets current users profile


## Testing

Description of how to test code...

- [ ] Run Get for profile and it should return current authorized users profile
