### PR TITLE
Add recommended products to user profile #1

### DIFF
--- a/bangazonapi/fixtures/recommendation.json
+++ b/bangazonapi/fixtures/recommendation.json
@@ -1,0 +1,29 @@
+[
+    {
+      "model": "bangazonapi.recommendation",
+      "pk": 1,
+      "fields": {
+        "customer": 6,
+        "product": 1,
+        "recommender": 5
+      }
+    },
+    {
+      "model": "bangazonapi.recommendation",
+      "pk": 2,
+      "fields": {
+        "customer": 5,
+        "product": 89,
+        "recommender": 6
+      }
+    },
+    {
+      "model": "bangazonapi.recommendation",
+      "pk": 3,
+      "fields": {
+        "customer": 7,
+        "product": 97,
+        "recommender": 7
+      }
+    }
+  ]

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -184,8 +184,11 @@ class Profile(ViewSet):
                     line_items, many=True, context={'request': request})
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
                 
+                cart["order"] = OrderSerializer(open_order, many=False, context={
+                                                'request': request}).data
+                cart["order"]["line_items"] = line_items.data
+
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,8 +81,10 @@ class Profile(ViewSet):
             }
         """
         try:
+            
             current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
+            current_user.recommendations = Recommendation.objects.filter(customer=current_user)
 
             serializer = ProfileSerializer(
                 current_user, many=False, context={'request': request})
@@ -182,9 +184,8 @@ class Profile(ViewSet):
                     line_items, many=True, context={'request': request})
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
-                cart["order"]["line_items"] = line_items.data
+                cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
+                
                 cart["order"]["size"] = len(line_items.data)
 
             except Order.DoesNotExist as ex:
@@ -361,6 +362,16 @@ class RecommenderSerializer(serializers.ModelSerializer):
     class Meta:
         model = Recommendation
         fields = ('product', 'customer',)
+        fields = ('id', 'product', 'customer',)
+
+class RecommendationsSerializer(serializers.ModelSerializer):
+    """JSON serializer for recommendations"""
+    recommender = CustomerSerializer()
+    product = ProfileProductSerializer()
+
+    class Meta:
+        model = Recommendation
+        fields = ('product', "recommender",)
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -371,11 +382,11 @@ class ProfileSerializer(serializers.ModelSerializer):
     """
     user = UserSerializer(many=False)
     recommends = RecommenderSerializer(many=True)
+    recommendations = RecommendationsSerializer(many=True)
 
     class Meta:
         model = Customer
-        fields = ('id', 'url', 'user', 'phone_number',
-                  'address', 'payment_types', 'recommends',)
+        fields = ('id', 'url', 'user', 'phone_number', 'address', 'payment_types', 'recommends', 'recommendations',)
         depth = 1
 
 


### PR DESCRIPTION
Description of PR that completes issue here...User recommendations #27
when /profile is requested from the API, the products that the user has recommended to other users is included in the response

Changes
added- Recommendation.Json
Edited - View /Profile.py

Item 1 added a recommendation.json so that we have a table created that allows us to show what recommender recommends what product to what customer.

Item 2 in Views/profiles wrote code to see who the current user is logged in and see what they have a user recommend an item to a customer customer. also list the product they are recommending and the name of that product


**Request**

GET `/profile`


## Testing

Description of how to test code...

- [ ] Run python3 manage.py loaddata recommendation to add the recommendations.json and add that table
- [ ] Run GET for getting the current users profile as well as now showing when the user has recommended. the product they recommended and they customer who they recommended it to.
