### PR TITLE
Delete payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -93,5 +93,4 @@ class Payments(ViewSet):
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})
         return Response(serializer.data)
-
-
+        

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -6,20 +6,7 @@ from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Payment, Customer
 
-class PaymentSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for Payment
 
-    Arguments:
-        serializers
-    """
-    class Meta:
-        model = Payment
-        url = serializers.HyperlinkedIdentityField(
-            view_name='payment',
-            lookup_field='id'
-        )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
 
 
 
@@ -93,4 +80,18 @@ class Payments(ViewSet):
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})
         return Response(serializer.data)
-        
+
+class PaymentSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for Payment
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = Payment
+        url = serializers.HyperlinkedIdentityField(
+            view_name='payment',
+            lookup_field='id'
+        )
+        fields = ('id', 'url', 'merchant_name', 'account_number',
+                  'expiration_date', 'create_date')

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -6,7 +6,20 @@ from rest_framework import serializers
 from rest_framework import status
 from bangazonapi.models import Payment, Customer
 
+class PaymentSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for Payment
 
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = Payment
+        url = serializers.HyperlinkedIdentityField(
+            view_name='payment',
+            lookup_field='id'
+        )
+        fields = ('id', 'url', 'merchant_name', 'account_number',
+                  'expiration_date', 'create_date')
 
 
 
@@ -21,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -43,6 +56,10 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+
+        except Payment.DoesNotExist as ex: #from models.model
+            return Response(ex.args[0], status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
             return HttpResponseServerError(ex)
 
@@ -78,17 +95,3 @@ class Payments(ViewSet):
         return Response(serializer.data)
 
 
-class PaymentSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for Payment
-
-    Arguments:
-        serializers
-    """
-    class Meta:
-        model = Payment
-        url = serializers.HyperlinkedIdentityField(
-            view_name='payment',
-            lookup_field='id'
-        )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -2,6 +2,7 @@ import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+from bangazonapi.models import Payment
 
 
 class PaymentTests(APITestCase):
@@ -25,6 +26,7 @@ class PaymentTests(APITestCase):
         # Add product to order
         url = "/paymenttypes"
         data = {
+            "paymentTypeId": 1,
             "merchant_name": "American Express",
             "account_number": "111-1111-1111",
             "expiration_date": "2024-12-31",
@@ -41,3 +43,28 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        """
+        Ensure we can delete an existing payment.
+        """
+        url = "/paymenttypes"
+
+        data = {
+            "paymentTypeId": 1,
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        url = '/paymenttypes/1'
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # GET paymentType AGAIN TO VERIFY 404 response
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -2,7 +2,7 @@ import datetime
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
-from bangazonapi.models import Payment
+
 
 
 class PaymentTests(APITestCase):


### PR DESCRIPTION
Description of PR that completes issue here...
TEST: Delete payment type #9
Add a test to the tests/payment.py module that verifies that a payment type can be deleted.
this will also Bug: Payment type info is incorrect #19
Customers are complaining that the expiration date on their payment types are incorrect. now this is correct.

## Changes

- Item 1 added test_delete_payment_type /bangazon/tests/payments.py so that we can delete an existing payment type.
- Item 2 corrected  /bangazonapi/views/paymenttype.py line 37 and line 38  as they were swapped for the creation and expiration dates, to 
       new_payment.expiration_date = request.data["expiration_date"]
        new_payment.create_date = request.data["create_date"]

- Item 3 in /bangazonapi/views/paymenttype.py  also added line 60 and 61 as an except incase the payment doesn't exist.
except Payment.DoesNotExist as ex: #from models.model
            return Response(ex.args[0], status=status.HTTP_404_NOT_FOUND)

- Item 4  also added payment type id "paymentTypeId": 1,



## Testing

Description of how to test code...

- [ ] Run python3 manage.py test tests -v 1 to run 7 tests
